### PR TITLE
Exit with status 1 if any test failed

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -175,6 +175,18 @@
 
   // apply replacer
   window.onload = function() {
+    if (typeof goog === 'undefined') {
+      /*
+       * FIXME: After upgrading to phantomjs 2.1.1 the phantomjs process
+       * executing the tests doesn't stop, causing travis builds to fail.
+       * This adapter seems to be injected into an empty page generated after
+       * running the tests. This causes an exception due the variable 'goog' not
+       * being defined and prevents phantomjs from closing properly.
+       * Further investigation is necessary but for now this solves the issue.
+       */
+      return;
+    }
+
     if (!goog.isDef(goog.testing.MultiTestRunner)) {
       replaceTestCase();
       replaceTestRunner();

--- a/lib/closure-library-phantomjs.js
+++ b/lib/closure-library-phantomjs.js
@@ -162,7 +162,7 @@ page.onCallback = function(obj) {
       reporter.writeFinish(data);
       // exit
       clearTimeout(waitTimer);
-      phantom.exit(0);
+      phantom.exit(data.success ? 0 : 1);
       break;
   }
   return 'Accepted';

--- a/lib/reporters.js
+++ b/lib/reporters.js
@@ -141,7 +141,7 @@ DotReporter.prototype.writeFinish = function(results) {
   var buf = [];
   buf.push('  ');
   if (results.success) {
-    buf.push(green(stats.passed + ' tests complate'));
+    buf.push(green(stats.passed + ' tests complete'));
     buf.push(gray(' (' + stats.time + ' ms)'));
   } else {
     buf.push(
@@ -228,7 +228,7 @@ SpecReporter.prototype.writeFinish = function(results) {
   var buf = [];
   buf.push('  ');
   if (results.success) {
-    buf.push(green(stats.passed + ' tests complate'));
+    buf.push(green(stats.passed + ' tests complete'));
     buf.push(gray(' (' + stats.time + ' ms)'));
   } else {
     buf.push(


### PR DESCRIPTION
Communicate the failure of any test by exiting with status 1. This is
convenient to propagate the failure to build scripts or a Makefile.
